### PR TITLE
Implemented support for dumping all config to a file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.11"
   - "iojs"
+  - "4.*"
+  - "5.*"
 before_install:
   - ./build_etcd.sh v0.3.0
 before_script: "./etcd/bin/etcd &"
 after_script: "NODE_ENV=test YOURPACKAGE_COVERAGE=1 ./node_modules/.bin/mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
 env: TRAVIS=True
+sudo: false

--- a/bin/renv.js
+++ b/bin/renv.js
@@ -209,13 +209,22 @@ var _ = require('lodash'),
         .help('h')
         .alias('h', 'help')
         .options(_.extend({
+          'f': {
+            alias: 'format',
+            default: 'console',
+            description: "how should the config be output (either json, or console)"
+          },
+          'o': {
+            alias: 'output',
+            description: "output configuration to a file, rather than standard out"
+          }
         }, options))
         .example('$0 dump', 'return config information for all environments')
         .argv;
 
       renv.getEnvironment('/')
         .then(function(environment) {
-          printEnvironment(environment);
+          printEnvironment(environment, null, argv.output);
         })
         .catch(function(err) {
           console.log(JSON.stringify(err));
@@ -310,7 +319,7 @@ function printEnvironment(environment, path, outputFile) {
   if (path) environment = traverse(environment).get(path.split('.'));
   path = path ? '.' + path : '';
 
-  if (argv.format === 'json') {
+  if (argv.format === 'json' || outputFile) {
     var json = JSON.stringify(environment, null, 2);
     if (outputFile) fs.writeFileSync(outputFile, json, 'utf-8');
     else console.log(JSON.stringify(environment, null, 2));


### PR DESCRIPTION
Added the `-f` and `-o` options to the `dump` command. Passed the outputFile option along to `printEnvironment()`. If json is set or if the output file option is set, it will now emit json instead of console-formatted data.

Added node 4.\* and 5.\* to the travis test targets, and switched to using Travis's newer infra.
